### PR TITLE
Fix "create pending commit status" Guard Condition

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -63245,17 +63245,22 @@ async function run() {
             ...get_commit_info(),
             ...get_pr_info()
         });
-        const body = {
-            params: {
-                ...run_params,
-                ...vcs_params,
+        const integrations_params = github_token
+            ? {
                 // these are deprecated:
                 'antithesis.integrations.type': INTEGRATIONS_TYPE_GITHUB,
                 'antithesis.integrations.callback_url': callback_url,
                 'antithesis.integrations.token': github_token,
                 // these aren't:
                 'antithesis.integrations.github.callback_url': callback_url,
-                'antithesis.integrations.github.token': github_token,
+                'antithesis.integrations.github.token': github_token
+            }
+            : {};
+        const body = {
+            params: {
+                ...run_params,
+                ...vcs_params,
+                ...integrations_params,
                 'antithesis.images': images,
                 'antithesis.config_image': config_image,
                 'antithesis.source': branch,

--- a/dist/index.js
+++ b/dist/index.js
@@ -63283,7 +63283,7 @@ async function run() {
         // Update GitHub commit status with pending status
         // Only if we have a callback URL & a token, because we want to make sure
         // that Antithesis could update the status to done
-        if (callback_url !== undefined && github_token !== undefined) {
+        if (callback_url && github_token) {
             let owner = github_1.context?.payload?.repository?.owner?.name;
             if (owner === undefined) {
                 owner = github_1.context?.payload?.repository?.owner?.login;

--- a/src/main.ts
+++ b/src/main.ts
@@ -182,7 +182,7 @@ export async function run(): Promise<void> {
     // Update GitHub commit status with pending status
     // Only if we have a callback URL & a token, because we want to make sure
     // that Antithesis could update the status to done
-    if (callback_url !== undefined && github_token !== undefined) {
+    if (callback_url && github_token) {
       let owner = context?.payload?.repository?.owner?.name
       if (owner === undefined) {
         owner = context?.payload?.repository?.owner?.login

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,19 +137,24 @@ export async function run(): Promise<void> {
       ...get_pr_info()
     })
 
+    const integrations_params = github_token
+      ? {
+          // these are deprecated:
+          'antithesis.integrations.type': INTEGRATIONS_TYPE_GITHUB,
+          'antithesis.integrations.callback_url': callback_url,
+          'antithesis.integrations.token': github_token,
+
+          // these aren't:
+          'antithesis.integrations.github.callback_url': callback_url,
+          'antithesis.integrations.github.token': github_token
+        }
+      : {}
+
     const body = {
       params: {
         ...run_params,
         ...vcs_params,
-
-        // these are deprecated:
-        'antithesis.integrations.type': INTEGRATIONS_TYPE_GITHUB,
-        'antithesis.integrations.callback_url': callback_url,
-        'antithesis.integrations.token': github_token,
-
-        // these aren't:
-        'antithesis.integrations.github.callback_url': callback_url,
-        'antithesis.integrations.github.token': github_token,
+        ...integrations_params,
 
         'antithesis.images': images,
         'antithesis.config_image': config_image,
@@ -157,6 +162,7 @@ export async function run(): Promise<void> {
         'antithesis.description': description,
         'antithesis.report.recipients': emails,
         'antithesis.test_name': test_name,
+
         ...additional_parameters
       }
     }


### PR DESCRIPTION
Previously, the action would attempt to create a pending commit status when `github_token` was an empty string.  Doing so would cause a non-fatal error `Failed to post a pending status on GitHub due to Error: Parameter token or opts.auth is required` in getOctokit. This PR changes the condition so that a pending commit status write is not attempted if `github_token` is an empty string (which is the default defined in `action.yml`).  This PR also omits all `antithesis.integrations` parameters from the Antithesis POST body whenever the `github_token` is `undefined`, `null`, or an empty string.