### PR TITLE
Handle credentials better, remove dead status check, and unawaited Github Call

### DIFF
--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core'
 import * as helpers from '../src/helpers'
 
 describe('successful_params_parsing', () => {
@@ -62,5 +63,19 @@ describe('successful_params_parsing', () => {
     p2='v2'`)
 
     expect(params).toEqual({ p1: "'inner_value_1=1'", p2: "'v2'" })
+  })
+
+  it('warns and skips lines without an = sign', async () => {
+    const warningMock = jest.spyOn(core, 'warning').mockImplementation()
+
+    const params = helpers.parse_additional_parameters(`p1=v1
+no_equals_here
+p2=v2`)
+
+    expect(params).toEqual({ p1: 'v1', p2: 'v2' })
+    expect(warningMock).toHaveBeenCalledTimes(1)
+    expect(warningMock).toHaveBeenCalledWith(
+      expect.stringContaining('no_equals_here')
+    )
   })
 })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -21,7 +21,7 @@ let getInputMock: jest.SpyInstance
 let setOutputMock: jest.SpyInstance
 let setFailedMock: jest.SpyInstance
 let axiosMock: jest.SpyInstance
-let createCommitStatusMock: jest.SpyInstance
+let createCommitStatusMock: jest.Mock
 
 describe('reasonable_pr_info', () => {
   it('undefined context.payload.pull_request returns {}', async () => {
@@ -112,9 +112,10 @@ parameter2=value2
       }
     }
 
-    createCommitStatusMock = jest
-      .spyOn(github, 'getOctokit')
-      .mockImplementation()
+    createCommitStatusMock = jest.fn().mockResolvedValue({})
+    jest.spyOn(github, 'getOctokit').mockReturnValue({
+      rest: { repos: { createCommitStatus: createCommitStatusMock } }
+    } as unknown as ReturnType<typeof github.getOctokit>)
   })
 
   it('calls Antithesis', async () => {
@@ -263,10 +264,10 @@ parameter2=value2
   })
 
   it('Handles Antithesis Non-2XX error code', async () => {
+    // Axios throws on non-2XX responses by default; the action lets the
+    // exception propagate to the outer catch.
     axiosMock.mockImplementation(() => {
-      return {
-        status: 404
-      }
+      throw new Error('Request failed with status code 404')
     })
 
     await main.run()
@@ -287,10 +288,34 @@ parameter2=value2
     )
 
     expect(setFailedMock).toHaveBeenCalledWith(
-      'Failed to submit request, received a non-2XX response code : 404'
+      'Request failed with status code 404'
     )
 
     expect(createCommitStatusMock).toHaveBeenCalledTimes(0)
+  })
+
+  it('logs an error but still succeeds when posting commit status fails', async () => {
+    axiosMock.mockImplementation(() => {
+      return {
+        status: 202
+      }
+    })
+    createCommitStatusMock.mockRejectedValue(new Error('GitHub is down'))
+
+    await main.run()
+    expect(runMock).toHaveReturned()
+
+    expect(axiosMock).toHaveBeenCalled()
+    expect(createCommitStatusMock).toHaveBeenCalledTimes(1)
+
+    // The commit-status failure is non-fatal: it logs an error...
+    expect(errorMock).toHaveBeenCalledWith(
+      'Failed to post a pending status on GitHub due to Error: GitHub is down'
+    )
+
+    // ...but the action still reports success and does not fail.
+    expect(setOutputMock).toHaveBeenCalledWith('result', 'Success')
+    expect(setFailedMock).not.toHaveBeenCalled()
   })
 
   it('Handles unexpected exceptions', async () => {
@@ -317,7 +342,7 @@ parameter2=value2
 
     expect(errorMock).toHaveBeenNthCalledWith(
       1,
-      'Failed to submit request : Error: An unexpected exception.'
+      'Failed to submit request : An unexpected exception.'
     )
 
     expect(setFailedMock).toHaveBeenCalledWith('An unexpected exception.')

--- a/dist/index.js
+++ b/dist/index.js
@@ -40549,9 +40549,10 @@ function shallow_prune_undefined_values(obj) {
     return Object.fromEntries(keys_with_defined_value.map(k => [k, obj[k]]));
 }
 function parse_parts(line) {
-    if (!line)
+    const trimmed = line?.trim();
+    if (!trimmed)
         return undefined;
-    const parts = line?.trim().split('=');
+    const parts = trimmed.split('=');
     if (parts && parts.length < 2) {
         core.warning(`These parameters could not be parsed and will not be sent to the webhook: ${line}`);
         return undefined;
@@ -40664,6 +40665,17 @@ function get_pr_info() {
  */
 async function run() {
     try {
+        // Read credentials first and register them as secrets so any accidental
+        // appearance in logs (e.g. axios error messages) is masked by the runner.
+        const username = core.getInput('username');
+        const password = core.getInput('password');
+        const github_token = core.getInput('github_token');
+        if (username)
+            core.setSecret(username);
+        if (password)
+            core.setSecret(password);
+        if (github_token)
+            core.setSecret(github_token);
         // Build the request URL
         const tenant = core.getInput('tenant');
         const notebook_name = core.getInput('notebook_name');
@@ -40684,8 +40696,6 @@ async function run() {
         // Read description information
         const description = core.getInput('description');
         core.info(`Desc: ${description}`);
-        // Build the request body
-        const github_token = core.getInput('github_token');
         // Extract the branch
         // (nb: the ref may be a branch *or a tag!*)
         const branch = github_1.context.ref?.replace('refs/heads/', '') ?? '';
@@ -40736,21 +40746,14 @@ async function run() {
                 ...additional_parameters
             }
         };
-        // Call into Antithesis
-        const username = core.getInput('username');
-        const password = core.getInput('password');
+        // Call into Antithesis. Axios throws on non-2XX by default, so any HTTP
+        // error falls through to the outer catch.
         const result = await axios_1.default.post(url, body, {
             auth: {
                 username,
                 password
             }
         });
-        if (result.status < 200 || result.status >= 300) {
-            const msg = `Failed to submit request, received a non-2XX response code : ${result.status}`;
-            core.error(msg);
-            core.setFailed(msg);
-            return;
-        }
         // Update GitHub commit status with pending status
         // Only if we have a callback URL & a token, because we want to make sure
         // that Antithesis could update the status to done
@@ -40762,11 +40765,11 @@ async function run() {
             const repo = github_1.context?.payload?.repository?.name;
             try {
                 const octokit = (0, github_1.getOctokit)(github_token);
-                const status_context = test_name !== undefined && test_name.length > 0
+                const status_context = test_name
                     ? `continuous-testing/antithesis (${test_name})`
                     : 'continuous-testing/antithesis';
                 if (owner && repo && sha) {
-                    octokit.rest.repos.createCommitStatus({
+                    await octokit.rest.repos.createCommitStatus({
                         owner,
                         repo,
                         sha,
@@ -40782,13 +40785,15 @@ async function run() {
             }
         }
         // Set status to success
-        core.info(`Successfully sent the request ${result}`);
+        core.info(`Successfully sent the request, status: ${result.status}`);
         core.setOutput('result', 'Success');
     }
     catch (error) {
-        core.error(`Failed to submit request : ${error}`);
-        if (error instanceof Error)
-            core.setFailed(error.message);
+        // Log only the message, not the full error — AxiosError stringification
+        // includes the request config (auth credentials).
+        const message = error instanceof Error ? error.message : String(error);
+        core.error(`Failed to submit request : ${message}`);
+        core.setFailed(message);
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
-  "name": "typescript-action",
+  "name": "antithesis-trigger-action",
   "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "typescript-action",
+      "name": "antithesis-trigger-action",
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^2.0.3",
         "@actions/github": "^6.0.1",
-        "@octokit/webhooks-definitions": "^3.68.1",
         "axios": "^1.16.1"
       },
       "devDependencies": {
@@ -1730,13 +1729,6 @@
       "dependencies": {
         "@octokit/openapi-types": "^24.2.0"
       }
-    },
-    "node_modules/@octokit/webhooks-definitions": {
-      "version": "3.68.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks-definitions/-/webhooks-definitions-3.68.1.tgz",
-      "integrity": "sha512-wa8koFift24mUsMarWP/wfl9kIwqL5TK9smsCRIyJYfs9iYQEoJsQjcmhyKCmevPA8Ja/K1ZTE4W8ABA0yMM8g==",
-      "deprecated": "Use @octokit/webhooks-types, @octokit/webhooks-schemas, or @octokit/webhooks-examples instead. See https://github.com/octokit/webhooks/issues/447",
-      "license": "MIT"
     },
     "node_modules/@ota-meshi/ast-token-store": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,21 +1,21 @@
 {
-  "name": "typescript-action",
-  "description": "GitHub Actions TypeScript template",
+  "name": "antithesis-trigger-action",
+  "description": "GitHub Action that triggers an Antithesis test run",
   "version": "0.11.0",
-  "author": "",
+  "author": "Antithesis",
   "private": true,
-  "homepage": "https://github.com/actions/typescript-action",
+  "homepage": "https://github.com/antithesishq/antithesis-trigger-action",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/actions/typescript-action.git"
+    "url": "git+https://github.com/antithesishq/antithesis-trigger-action.git"
   },
   "bugs": {
-    "url": "https://github.com/actions/typescript-action/issues"
+    "url": "https://github.com/antithesishq/antithesis-trigger-action/issues"
   },
   "keywords": [
     "actions",
-    "node",
-    "setup"
+    "antithesis",
+    "testing"
   ],
   "exports": {
     ".": "./dist/index.js"
@@ -68,7 +68,6 @@
   "dependencies": {
     "@actions/core": "^2.0.3",
     "@actions/github": "^6.0.1",
-    "@octokit/webhooks-definitions": "^3.68.1",
     "axios": "^1.16.1"
   },
   "devDependencies": {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,9 +18,10 @@ export function shallow_prune_undefined_values<O extends object>(
 function parse_parts(
   line: string
 ): { name: string; value: string } | undefined {
-  if (!line) return undefined
+  const trimmed = line?.trim()
+  if (!trimmed) return undefined
 
-  const parts = line?.trim().split('=')
+  const parts = trimmed.split('=')
 
   if (parts && parts.length < 2) {
     core.warning(

--- a/src/main.ts
+++ b/src/main.ts
@@ -67,6 +67,15 @@ export function get_pr_info():
  */
 export async function run(): Promise<void> {
   try {
+    // Read credentials first and register them as secrets so any accidental
+    // appearance in logs (e.g. axios error messages) is masked by the runner.
+    const username = core.getInput('username')
+    const password = core.getInput('password')
+    const github_token = core.getInput('github_token')
+    if (username) core.setSecret(username)
+    if (password) core.setSecret(password)
+    if (github_token) core.setSecret(github_token)
+
     // Build the request URL
     const tenant: string = core.getInput('tenant')
     const notebook_name: string = core.getInput('notebook_name')
@@ -98,9 +107,6 @@ export async function run(): Promise<void> {
     const description = core.getInput('description')
 
     core.info(`Desc: ${description}`)
-
-    // Build the request body
-    const github_token = core.getInput('github_token')
 
     // Extract the branch
     // (nb: the ref may be a branch *or a tag!*)
@@ -167,23 +173,14 @@ export async function run(): Promise<void> {
       }
     }
 
-    // Call into Antithesis
-    const username = core.getInput('username')
-    const password = core.getInput('password')
-
+    // Call into Antithesis. Axios throws on non-2XX by default, so any HTTP
+    // error falls through to the outer catch.
     const result = await axios.post(url, body, {
       auth: {
         username,
         password
       }
     })
-
-    if (result.status < 200 || result.status >= 300) {
-      const msg = `Failed to submit request, received a non-2XX response code : ${result.status}`
-      core.error(msg)
-      core.setFailed(msg)
-      return
-    }
 
     // Update GitHub commit status with pending status
     // Only if we have a callback URL & a token, because we want to make sure
@@ -199,13 +196,12 @@ export async function run(): Promise<void> {
       try {
         const octokit = getOctokit(github_token)
 
-        const status_context =
-          test_name !== undefined && test_name.length > 0
-            ? `continuous-testing/antithesis (${test_name})`
-            : 'continuous-testing/antithesis'
+        const status_context = test_name
+          ? `continuous-testing/antithesis (${test_name})`
+          : 'continuous-testing/antithesis'
 
         if (owner && repo && sha) {
-          octokit.rest.repos.createCommitStatus({
+          await octokit.rest.repos.createCommitStatus({
             owner,
             repo,
             sha,
@@ -221,10 +217,13 @@ export async function run(): Promise<void> {
       }
     }
     // Set status to success
-    core.info(`Successfully sent the request ${result}`)
+    core.info(`Successfully sent the request, status: ${result.status}`)
     core.setOutput('result', 'Success')
   } catch (error) {
-    core.error(`Failed to submit request : ${error}`)
-    if (error instanceof Error) core.setFailed(error.message)
+    // Log only the message, not the full error — AxiosError stringification
+    // includes the request config (auth credentials).
+    const message = error instanceof Error ? error.message : String(error)
+    core.error(`Failed to submit request : ${message}`)
+    core.setFailed(message)
   }
 }


### PR DESCRIPTION
  - Register username/password/github_token via core.setSecret and log only error.message so AxiosError stringification (which includes the request config) can't leak credentials into job logs by accident.
  - Remove the unreachable non-2XX status check; axios throws on non-2XX by default, so the outer catch already handles it. Update the test to make axios throw, matching real behavior.
  - Await octokit.rest.repos.createCommitStatus so its errors are caught and the request flushes before the action exits. Update the test mock to return a real-shaped Octokit so the await resolves, and add coverage for the non-fatal failure path.
  - Misc cleanup: log result.status instead of stringifying the response to "[object Object]"; stop warning on whitespace-only lines in additional_parameters; drop the always-true `test_name !== undefined` guard; remove the unused @octokit/webhooks-definitions dependency; replace the typescript-action template metadata in package.json.